### PR TITLE
複数ファイルの編集状態を一元管理するプリミティブを実装

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "arktype": "^2.1.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "deepmerge": "^4.3.1",
         "lodash": "^4.17.21",
         "lucide-solid": "^0.542.0",
         "neverthrow": "^8.2.0",
@@ -497,6 +498,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "arktype": "^2.1.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "deepmerge": "^4.3.1",
     "lodash": "^4.17.21",
     "lucide-solid": "^0.542.0",
     "neverthrow": "^8.2.0",

--- a/src/features/audio-file/index.ts
+++ b/src/features/audio-file/index.ts
@@ -7,6 +7,10 @@ export * from "./components/DirectorySelector";
 // Providers
 export * from "./providers/audio-files-manager-provider";
 export type { AudioFilesManager } from "./primitives/audio-files-manager";
+export {
+  type AudioFileStore,
+  AudioFileStoreProvider,
+} from "./primitives/audio-file-store";
 
 // Schemas
 export * from "./schemas";

--- a/src/features/audio-file/primitives/audio-file-store.test.ts
+++ b/src/features/audio-file/primitives/audio-file-store.test.ts
@@ -1,0 +1,208 @@
+/** @vitest-environment jsdom */
+
+import { errAsync, okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Album, Artists, AudioFile, Path, Title } from "../schemas";
+import { createAudioFileStore } from "./audio-file-store";
+
+const buildAudioFile = (
+  id: string,
+  title: string = "Title",
+  album: string = "Album",
+  artists: string[] = ["Artist"],
+): AudioFile =>
+  ({
+    id,
+    path: `/music/${id}.mp3` as Path,
+    id3Tag: {
+      title: title as Title,
+      album: album as Album,
+      artists: artists as unknown as Artists,
+    },
+  }) as unknown as AudioFile;
+
+const createMockUpdateCommand = () => vi.fn();
+
+describe("createAudioFileStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("初期状態", () => {
+    it("初期化時に空の状態で作成される", () => {
+      const store = createAudioFileStore([], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+      expect(store.originalFiles()).toEqual([]);
+      expect(store.isDirty()).toBe(false);
+      expect(store.pending()).toBe(false);
+    });
+  });
+
+  describe("updateFile: オブジェクト指定", () => {
+    it("同一値をupdateFileしても差分として保持される", () => {
+      const f1 = buildAudioFile("1", "Old Title", "Old Album");
+      const store = createAudioFileStore([f1], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+
+      store.updateFile("1", {
+        id3Tag: { title: f1.id3Tag.title, album: f1.id3Tag.album },
+      });
+      // NOTE: ここでは同値なので本来は差分消去ロジックTODOが効けば登録されない想定。現在はそのまま格納される。挙動をそのままテスト。
+      expect(store.changes()["1"].id3Tag?.title).toBe(f1.id3Tag.title);
+      expect(store.isDirty()).toBe(true);
+    });
+
+    it("既存差分がある状態でartistsを更新すると配列が上書きされる", () => {
+      const f1 = buildAudioFile("1", "T", "A");
+      const store = createAudioFileStore([f1], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+
+      store.updateFile("1", { id3Tag: { title: null } });
+      store.updateFile("1", {
+        id3Tag: { artists: ["New Artist"] as unknown as Artists },
+      });
+
+      const c = store.changes()["1"];
+      expect(c.id3Tag?.title).toBeNull();
+      expect(c.id3Tag?.artists).toEqual(["New Artist"]);
+    });
+  });
+
+  describe("updateFile", () => {
+    it("関数指定のupdateFileで差分を設定できる", () => {
+      const f = buildAudioFile("1");
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+      store.updateFile("1", () => ({ id3Tag: { title: null } }));
+      expect(store.changes()["1"].id3Tag?.title).toBeNull();
+    });
+
+    it("関数指定のupdateFileで既存差分を置き換えられる", () => {
+      const f = buildAudioFile("1");
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+      store.updateFile("1", { id3Tag: { title: null, album: null } });
+      store.updateFile("1", (prev) => {
+        expect(prev.id3Tag?.album).toBeNull(); // 前状態参照可能
+        return { id3Tag: { artists: ["X"] as unknown as Artists } };
+      });
+      const c = store.changes()["1"];
+      expect(c.id3Tag?.title).toBeUndefined();
+      expect(c.id3Tag?.artists).toEqual(["X"]);
+    });
+  });
+
+  describe("isDirty/isFileDirty", () => {
+    it("差分追加前後でisDirtyとisFileDirtyのフラグが変化する", () => {
+      const f = buildAudioFile("1");
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+      expect(store.isDirty()).toBe(false);
+      expect(store.isFileDirty("1")).toBe(false);
+      store.updateFile("1", { id3Tag: { title: null } });
+      expect(store.isDirty()).toBe(true);
+      expect(store.isFileDirty("1")).toBe(true);
+      expect(store.isFileDirty("unknown")).toBe(false);
+    });
+  });
+
+  describe("saveFile", () => {
+    it("差分ありのsaveFileでファイルが更新されchangesがクリアされる", async () => {
+      const f = buildAudioFile("1", "Old", "Alb");
+      const updatedFile = buildAudioFile("1", "New", "Alb", ["Artist"]);
+      const updateFn = vi.fn().mockReturnValue(okAsync(updatedFile));
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: updateFn,
+      });
+
+      store.updateFile("1", { id3Tag: { title: "New" as unknown as Title } });
+
+      const result = await store.saveFile("1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.id3Tag.title).toBe("New");
+      expect(updateFn).toHaveBeenCalledWith({
+        patch: { id: "1", title: "New" },
+      });
+      expect(store.changes()["1"]).toBeUndefined();
+      expect(store.isDirty()).toBe(false);
+    });
+
+    it("差分なしのsaveFileではコマンドを呼び出さない", async () => {
+      const f = buildAudioFile("1");
+      const updateFn = vi.fn();
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: updateFn,
+      });
+      const result = await store.saveFile("1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(f);
+      expect(updateFn).not.toHaveBeenCalled();
+    });
+
+    it("存在しないIDをsaveFileするとエラーを返す", async () => {
+      const store = createAudioFileStore([], {
+        updateAudioFileCommand: vi.fn(),
+      });
+      const result = await store.saveFile("x");
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error).toBe("File not found");
+    });
+
+    it("saveFileでコマンドが失敗した場合エラーを返しchangesが保持される", async () => {
+      const f = buildAudioFile("1");
+      const updateFn = vi.fn().mockReturnValue(errAsync("API Error"));
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: updateFn,
+      });
+      store.updateFile("1", { id3Tag: { title: null } });
+      const result = await store.saveFile("1");
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error).toBe("API Error");
+      expect(store.changes()["1"].id3Tag?.title).toBeNull();
+    });
+
+    it("saveFileを並行実行しようとすると二重実行が防止される", async () => {
+      const f = buildAudioFile("1");
+      // 1回目の実行が手動で解決するまで保留状態になるようにする
+      let resolveFn: (v: unknown) => void = () => {};
+      const p: Promise<unknown> = new Promise((res) => {
+        resolveFn = res;
+      });
+      const updateFn = vi.fn().mockReturnValue(okAsync(p as unknown));
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: updateFn,
+      });
+      store.updateFile("1", { id3Tag: { title: null } });
+      store.saveFile("1");
+      const second = store.saveFile("1");
+      const secondResult = await second;
+      expect(secondResult.isErr()).toBe(true);
+      if (secondResult.isErr())
+        expect(secondResult.error).toBe("Another operation is in progress");
+      // 解放
+      resolveFn(f);
+    });
+  });
+
+  describe("resetWithFiles", () => {
+    it("resetWithFilesでファイルが差し替えられchangesがクリアされる", () => {
+      const f = buildAudioFile("1");
+      const store = createAudioFileStore([f], {
+        updateAudioFileCommand: createMockUpdateCommand(),
+      });
+      store.updateFile("1", { id3Tag: { title: null } });
+      expect(store.isDirty()).toBe(true);
+      const newF = buildAudioFile("2");
+      store.resetWithFiles([newF]);
+      expect(store.originalFiles().map((f) => f.id)).toEqual(["2"]);
+      expect(store.isDirty()).toBe(false);
+      expect(store.changes()).toEqual({});
+    });
+  });
+});

--- a/src/features/audio-file/primitives/audio-file-store.tsx
+++ b/src/features/audio-file/primitives/audio-file-store.tsx
@@ -1,0 +1,231 @@
+import { errAsync, okAsync, type ResultAsync } from "neverthrow";
+import {
+  type Accessor,
+  createContext,
+  createSignal,
+  type ParentComponent,
+  type Setter,
+  useContext,
+} from "solid-js";
+import { createStore, produce, reconcile } from "solid-js/store";
+import { type UpdateAudioFile, useCommands } from "@/tauri/commands";
+import type { AudioFilePatchDTO } from "@/tauri/dto";
+import {
+  type AudioFile,
+  type AudioFileChanges,
+  combineChanges,
+} from "../schemas";
+
+export interface AudioFileStore {
+  // state
+  /** 変更前の音声ファイルのリスト */
+  originalFiles: Accessor<AudioFile[]>;
+
+  /** 各ファイルの未保存の変更内容 */
+  changes: Accessor<Record<string, AudioFileChanges>>;
+
+  /** 何らかの音声ファイルに未保存の変更があるか否か */
+  isDirty: Accessor<boolean>;
+
+  /** 指定した音声ファイルに未保存の変更があるか否か */
+  isFileDirty: (id: string) => boolean;
+
+  /** 永続化処理が実行中かどうか */
+  pending: Accessor<boolean>;
+
+  // actions
+  /**
+   * 音声ファイルの変更内容を更新する（メモリ上のみ、永続化はしない）
+   *
+   * @param id ファイルID
+   * @param updater 変更内容のオブジェクト、または既存の変更内容を受け取って新しい変更内容を返す関数
+   * - 変更内容オブジェクトの場合、既存の変更内容とマージされる
+   * - 関数の場合、既存の変更内容を受け取って新しい変更内容を計算し、置き換える
+   */
+  updateFile: (
+    id: string,
+    updater: AudioFileChanges | ((prev: AudioFileChanges) => AudioFileChanges),
+  ) => void;
+
+  /**
+   * 指定した音声ファイルの変更を永続化する
+   *
+   * @param id ファイルID
+   * @returns 更新後の音声ファイル、またはエラー
+   */
+  saveFile: (id: string) => ResultAsync<AudioFile, string>;
+
+  /**
+   * ストアの状態を新しい音声ファイル一覧でリセットする
+   *
+   * 未保存の変更はすべて破棄される
+   *
+   * @param audioFiles 新しい音声ファイル一覧
+   */
+  resetWithFiles: (audioFiles: AudioFile[]) => void;
+}
+
+interface AudioFileStoreConfig {
+  updateAudioFileCommand: UpdateAudioFile;
+}
+
+interface AudioFilesState {
+  files: AudioFile[];
+  changes: Record<string, AudioFileChanges>;
+}
+
+// 一時的な変換関数
+// TODO: AudioFilePatchDTOではなくAudioFileChangesを使うようにする
+const convertChangesToDTO = (
+  changes: AudioFileChanges,
+  id: string,
+): AudioFilePatchDTO => {
+  const dto: AudioFilePatchDTO = { id };
+  if (changes.path !== undefined) {
+    dto.path = changes.path;
+  }
+  if (changes.id3Tag !== undefined) {
+    if (changes.id3Tag.title !== undefined) {
+      dto.title = changes.id3Tag.title;
+    }
+    if (changes.id3Tag.artists !== undefined) {
+      dto.artists = changes.id3Tag.artists;
+    }
+    if (changes.id3Tag.album !== undefined) {
+      dto.album = changes.id3Tag.album;
+    }
+  }
+  return dto;
+};
+
+/**
+ * pending状態の管理を伴う非同期処理をおこなう関数を作成する
+ */
+const withPendingState = <T,>(
+  operation: () => ResultAsync<T, string>,
+  pendingSignal: [Accessor<boolean>, Setter<boolean>],
+): ResultAsync<T, string> => {
+  const [pending, setPending] = pendingSignal;
+
+  if (pending()) {
+    return errAsync("Another operation is in progress");
+  }
+
+  setPending(true);
+
+  return operation()
+    .map((value) => {
+      setPending(false);
+      return value;
+    })
+    .mapErr((error) => {
+      setPending(false);
+      return error;
+    });
+};
+
+const createAudioFileStore = (
+  initialAudioFiles: AudioFile[],
+  { updateAudioFileCommand }: AudioFileStoreConfig,
+): AudioFileStore => {
+  const [state, setState] = createStore<AudioFilesState>({
+    files: initialAudioFiles,
+    changes: {},
+  });
+
+  const isDirty = () => Object.keys(state.changes).length > 0;
+
+  const isFileDirty = (id: string): boolean =>
+    Object.keys(state.changes[id] ?? {}).length > 0;
+
+  const pendingSignal = createSignal<boolean>(false);
+  const [pending, setPending] = pendingSignal;
+
+  const updateFile = (
+    id: string,
+    updater: AudioFileChanges | ((prev: AudioFileChanges) => AudioFileChanges),
+  ) => {
+    // TODO: 実質的に変更がない場合、changesの項目を消去する（ファイル単位・1つのプロパティ単位）
+    if (typeof updater === "function") {
+      // 関数の場合：既存の変更内容を受け取って新しい変更内容を計算し、置き換える
+      setState("changes", id, (prev) => updater(prev ?? {}));
+    } else {
+      // オブジェクトの場合：既存の変更内容と新しい変更内容をマージする
+      const newChanges = combineChanges(state.changes[id] ?? {}, updater);
+      setState("changes", id, reconcile(newChanges));
+    }
+  };
+
+  const saveFile = (id: string): ResultAsync<AudioFile, string> =>
+    withPendingState(() => {
+      const originalFile = state.files.find((file) => file.id === id);
+      if (!originalFile) {
+        return errAsync("File not found");
+      }
+
+      const changes = state.changes[id];
+      if (!changes) {
+        return okAsync(originalFile);
+      }
+
+      // TODO: AudioFilePatchDTOではなくAudioFileChangesを使うようにする
+      return updateAudioFileCommand({
+        patch: convertChangesToDTO(changes, id),
+      }).map((newFile) => {
+        // オリジナルのファイルの状態を更新し、変更内容をクリア
+        setState("files", (file) => file.id === newFile.id, reconcile(newFile));
+        setState(
+          "changes",
+          produce((prevChanges) => {
+            delete prevChanges[id];
+          }),
+        );
+
+        return newFile;
+      });
+    }, [pending, setPending]);
+
+  const resetWithFiles = (audioFiles: AudioFile[]) => {
+    setState({
+      files: audioFiles,
+      changes: {},
+    });
+  };
+
+  return {
+    originalFiles: () => state.files,
+    changes: () => state.changes,
+    isDirty,
+    isFileDirty,
+    pending,
+
+    updateFile,
+    saveFile,
+    resetWithFiles,
+  };
+};
+
+const AudioFileStoreContext = createContext<AudioFileStore>();
+
+export const AudioFileStoreProvider: ParentComponent = (props) => {
+  const { updateAudioFile } = useCommands();
+  const audioFileStore = createAudioFileStore([], {
+    updateAudioFileCommand: updateAudioFile,
+  });
+
+  return (
+    <AudioFileStoreContext.Provider value={audioFileStore}>
+      {props.children}
+    </AudioFileStoreContext.Provider>
+  );
+};
+
+export const useAudioFileStore = (): AudioFileStore => {
+  const context = useContext(AudioFileStoreContext);
+  if (!context) {
+    throw new Error(
+      "useAudioFileStore must be used within an AudioFileStoreProvider",
+    );
+  }
+  return context;
+};

--- a/src/features/audio-file/primitives/audio-file-store.tsx
+++ b/src/features/audio-file/primitives/audio-file-store.tsx
@@ -101,7 +101,7 @@ const convertChangesToDTO = (
 /**
  * pending状態の管理を伴う非同期処理をおこなう関数を作成する
  */
-const withPendingState = <T,>(
+export const withPendingState = <T,>(
   operation: () => ResultAsync<T, string>,
   pendingSignal: [Accessor<boolean>, Setter<boolean>],
 ): ResultAsync<T, string> => {
@@ -124,7 +124,7 @@ const withPendingState = <T,>(
     });
 };
 
-const createAudioFileStore = (
+export const createAudioFileStore = (
   initialAudioFiles: AudioFile[],
   { updateAudioFileCommand }: AudioFileStoreConfig,
 ): AudioFileStore => {

--- a/src/features/audio-file/schemas.test.ts
+++ b/src/features/audio-file/schemas.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Album,
+  Artists,
+  AudioFile,
+  AudioFileChanges,
+  Path,
+  Title,
+} from "./schemas";
+import { applyChanges, combineChanges } from "./schemas";
+
+const createMockAudioFile = (): AudioFile => {
+  return {
+    id: "test-id-123",
+    path: "/path/to/test.mp3" as Path,
+    id3Tag: {
+      title: "Original Title" as Title,
+      album: "Original Album" as Album,
+      artists: ["Original Artist"] as Artists,
+    },
+  } as AudioFile;
+};
+
+const createTypedValues = (
+  title: string,
+  album: string,
+  artists: string[],
+  path: string,
+) => {
+  return {
+    title: title as Title,
+    album: album as Album,
+    artists: artists as Artists,
+    path: path as Path,
+  };
+};
+
+describe("applyChanges", () => {
+  it("オリジナルのAudioFileに変更をマージする", () => {
+    const original = createMockAudioFile();
+    const typedValues = createTypedValues(
+      "New Title",
+      "New Album",
+      ["Test"],
+      "/test.mp3",
+    );
+
+    const changes: AudioFileChanges = {
+      id3Tag: {
+        title: typedValues.title,
+        album: typedValues.album,
+      },
+    };
+
+    const result = applyChanges(original, changes);
+
+    expect(result.id).toBe("test-id-123");
+    expect(result.path).toBe("/path/to/test.mp3");
+    expect(result.id3Tag.title).toBe("New Title");
+    expect(result.id3Tag.album).toBe("New Album");
+    expect(result.id3Tag.artists).toEqual(["Original Artist"]); // 変更されていない値は保持される
+  });
+
+  it("id3Tagフィールドのnull値を処理する", () => {
+    const original = createMockAudioFile();
+    const changes: AudioFileChanges = {
+      id3Tag: {
+        title: null,
+        artists: null,
+      },
+    };
+
+    const result = applyChanges(original, changes);
+
+    expect(result.id3Tag.title).toBeNull();
+    expect(result.id3Tag.artists).toBeNull();
+    expect(result.id3Tag.album).toBe("Original Album"); // 変更されていない値は保持される
+  });
+
+  it("配列を完全に上書きする（マージしない）", () => {
+    const original = createMockAudioFile();
+    const typedValues = createTypedValues(
+      "Test",
+      "Test",
+      ["New Artist 1", "New Artist 2"],
+      "/test.mp3",
+    );
+
+    const changes: AudioFileChanges = {
+      id3Tag: {
+        artists: typedValues.artists,
+      },
+    };
+
+    const result = applyChanges(original, changes);
+
+    expect(result.id3Tag.artists).toEqual(["New Artist 1", "New Artist 2"]);
+    // 元の配列["Original Artist"]と新しい配列がマージされていないことを確認
+    expect(result.id3Tag.artists).not.toContain("Original Artist");
+  });
+
+  it("空のchangesオブジェクトを処理する", () => {
+    const original = createMockAudioFile();
+    const changes: AudioFileChanges = {};
+
+    const result = applyChanges(original, changes);
+
+    expect(result).toEqual(original);
+  });
+
+  it("pathの変更を処理する", () => {
+    const original = createMockAudioFile();
+    const typedValues = createTypedValues(
+      "Test",
+      "Test",
+      ["Test"],
+      "/new/path/to/file.mp3",
+    );
+
+    const changes: AudioFileChanges = {
+      path: typedValues.path,
+    };
+
+    const result = applyChanges(original, changes);
+
+    expect(result.path).toBe("/new/path/to/file.mp3");
+    expect(result.id3Tag).toEqual(original.id3Tag); // id3Tagは変更されない
+  });
+});
+
+describe("combineChanges", () => {
+  it("競合する変更を処理する（後の変更が優先）", () => {
+    const typedValues1 = createTypedValues(
+      "First Title",
+      "First Album",
+      ["Test"],
+      "/test.mp3",
+    );
+    const typedValues2 = createTypedValues(
+      "Second Title",
+      "Test",
+      ["Second Artist"],
+      "/test.mp3",
+    );
+
+    const changes1: AudioFileChanges = {
+      id3Tag: {
+        title: typedValues1.title,
+        album: typedValues1.album,
+      },
+    };
+
+    const changes2: AudioFileChanges = {
+      id3Tag: {
+        title: typedValues2.title, // これが優勝する
+        artists: typedValues2.artists,
+      },
+    };
+
+    const result = combineChanges(changes1, changes2);
+
+    expect(result.id3Tag?.title).toBe("Second Title"); // 後の変更が適用される
+    expect(result.id3Tag?.album).toBe("First Album"); // 競合しない値は保持される
+    expect(result.id3Tag?.artists).toEqual(["Second Artist"]);
+  });
+
+  it("空のchanges配列を処理する", () => {
+    const result = combineChanges();
+
+    expect(result).toEqual({});
+  });
+
+  it("配列の上書き動作を保持する", () => {
+    const typedValues1 = createTypedValues(
+      "Test",
+      "Test",
+      ["Artist 1", "Artist 2"],
+      "/test.mp3",
+    );
+    const typedValues2 = createTypedValues(
+      "Test",
+      "Test",
+      ["Artist 3"],
+      "/test.mp3",
+    );
+
+    const changes1: AudioFileChanges = {
+      id3Tag: {
+        artists: typedValues1.artists,
+      },
+    };
+
+    const changes2: AudioFileChanges = {
+      id3Tag: {
+        artists: typedValues2.artists,
+      },
+    };
+
+    const result = combineChanges(changes1, changes2);
+
+    expect(result.id3Tag?.artists).toEqual(["Artist 3"]);
+    // 配列がマージされていないことを確認
+    expect(result.id3Tag?.artists).not.toContain("Artist 1");
+    expect(result.id3Tag?.artists).not.toContain("Artist 2");
+  });
+
+  it("null値を含む変更を処理する", () => {
+    const typedValues1 = createTypedValues(
+      "Some Title",
+      "Some Album",
+      ["Test"],
+      "/test.mp3",
+    );
+    const typedValues2 = createTypedValues(
+      "Test",
+      "Test",
+      ["Some Artist"],
+      "/test.mp3",
+    );
+
+    const changes1: AudioFileChanges = {
+      id3Tag: {
+        title: typedValues1.title,
+        album: typedValues1.album,
+      },
+    };
+
+    const changes2: AudioFileChanges = {
+      id3Tag: {
+        title: null, // null値で上書き
+        artists: typedValues2.artists,
+      },
+    };
+
+    const result = combineChanges(changes1, changes2);
+
+    expect(result.id3Tag?.title).toBeNull();
+    expect(result.id3Tag?.album).toBe("Some Album");
+    expect(result.id3Tag?.artists).toEqual(["Some Artist"]);
+  });
+});

--- a/src/features/audio-file/schemas.ts
+++ b/src/features/audio-file/schemas.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import deepmerge from "deepmerge";
 
 export const Title = type("string.trim.preformatted > 0").brand("Title");
 export type Title = typeof Title.infer;
@@ -38,3 +39,37 @@ export const AudioFile = type({
   id3Tag: Id3Tag,
 }).brand("AudioFile");
 export type AudioFile = typeof AudioFile.infer;
+
+export interface AudioFileChanges {
+  path?: Path;
+  id3Tag?: {
+    title?: Title | null;
+    album?: Album | null;
+    artists?: Artists | null;
+  };
+}
+
+export interface AudioFilePatch {
+  id: string;
+  changes: AudioFileChanges;
+}
+
+export const applyChanges = (
+  original: AudioFile,
+  changes: AudioFileChanges,
+): AudioFile =>
+  deepmerge<AudioFile, AudioFileChanges>(original, changes, {
+    arrayMerge: (_destinationArray, sourceArray) => sourceArray,
+  });
+
+export const combineChanges = (
+  ...changes: AudioFileChanges[]
+): AudioFileChanges => {
+  return changes.reduce(
+    (acc, change) =>
+      deepmerge<AudioFileChanges>(acc, change, {
+        arrayMerge: (_destinationArray, sourceArray) => sourceArray,
+      }),
+    {},
+  );
+};


### PR DESCRIPTION
### 目的
一括保存機能への準備として、複数の音声ファイルの編集・保存をおこなう機能を作成する

### 新機能
- 音声ファイルの編集状態管理や永続化をおこなう`createAudioFileStore` 
- `createAudioFileStore` をアプリ全体で使用するためのプロバイダー
- 音声ファイル編集のための`AudioFileChanges`型や汎用的な純粋関数

### 今後の予定
- 既存のファイル編集システムを`createAudioFileStore`で置き換える
- 音声ファイルの一括保存機能を実装する
